### PR TITLE
Shamebot Drinking Buddy

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -30,6 +30,8 @@ var FFXIVManager = require("./modules/ffxivModule.js")
 var FFXIVInfo = new FFXIVManager(bot);
 var SteamManager = require("./modules/steamModule.js")
 var steamManager = new SteamManager(bot);
+var DrinkingManager = require("./modules/drinkingModule.js")
+var drinkingManager = new DrinkingManager(bot);
 var request = require("request"),
 	cheerio = require("cheerio");
 
@@ -43,6 +45,7 @@ MongoClient.connect("mongodb://localhost:27017shamebotdb", { useUnifiedTopology:
 	steamIDCollection = db.collection('SteamIDtoDiscordID');
 	PCBuildCollection = db.collection('PCBuilds');
 	ffxivCollection = db.collection('FFXIV');
+	drinkingCollection = db.collection('Drinking');
 });
 
 //initialize file transport for winston
@@ -308,6 +311,17 @@ bot.on("message", message => {
 	}
 
 	//End FFXIV
+
+	//Drinking
+	if(message.content.includes("!cheers")) {
+		drinkingManager.addDrinks(message, drinkingCollection);
+	}
+
+	if(message.content.includes("!drunk")) {
+		drinkingManager.getStatus(message, drinkingCollection);
+	}
+
+	//End Drinking
 
 	//help
 	if (message.content.includes("!help")) {

--- a/modules/drinkingModule.js
+++ b/modules/drinkingModule.js
@@ -1,0 +1,76 @@
+const Discord = require('discord.js');
+
+var DrinkingManager = function (bot) {
+    this.addDrinks = function (message, dbCollection) {
+        var beerCount = (message.content.match(/🍺/g) || []).length;
+        var wineCount = (message.content.match(/🍷/g) || []).length;
+        var liquorCount = (message.content.match(/🥃/g) || []).length;
+
+        const doc = {
+            createdAt: new Date(),
+            beer: beerCount,
+            wine: wineCount,
+            liquor: liquorCount
+        };
+
+        dbCollection.insertOne(doc)
+            .then((obj) => {
+                this.getStatus(message, dbCollection);
+            })
+            .catch((err) => {
+                message.channel.send("Party Foul: " + err);
+            })
+    }
+
+    this.getStatus = function (message, dbCollection) {
+        dbCollection.aggregate([
+            {
+                $match: { createdAt: { $gt: new Date(Date.now() - 24 * 60 * 60 * 1000) } }
+            },
+            {
+                $group: {
+                    _id: null,
+                    earliestDrink: { $min: "$createdAt" },
+                    beerCount: { $sum: "$beer" },
+                    wineCount: { $sum: "$wine" },
+                    liquorCount: { $sum: "$liquor" }
+                }
+            }
+        ]).toArray(
+            function (err, result) {
+                if (err) throw err;
+
+                const sums = result[0];
+                console.log(sums);
+                const beerCount = sums.beerCount;
+                const wineCount = sums.wineCount;
+                const liquorCount = sums.liquorCount;
+                const earliestDrink = sums.earliestDrink;
+
+                const hoursDrinking = Math.round(Math.abs(new Date() - earliestDrink) / (60 * 60 * 1000) * 100) / 100
+
+                
+                const GenderConstant = 0.68
+                const Weight = 240.0
+
+                // BAC = (Standard Drinks * 0.06 * 100 * 1.055 / Weight * Gender Constant) ­ (0.015 * Hours)
+                const BAC = Math.round((((beerCount + wineCount + liquorCount) * 0.06 * 100 * 1.055 / Weight * GenderConstant) - (0.015 * hoursDrinking)) * 100) / 100
+
+                const embed = new Discord.MessageEmbed()
+                    .setColor('#DBE4EB')
+                    .setAuthor("Shamebot Drinkin' Buddy")
+                    .setThumbnail("https://findicons.com/files/icons/1202/futurama_vol_6_the_movies/256/steamboat_bender.png")
+                    .setTitle("BAC: " + BAC + "%")
+                    .setDescription("Started drinking " + hoursDrinking + " hours ago.")
+                    .addFields(
+                        { name: '🍺 Beer', value: beerCount, inline: true },
+                        { name: '🍷 Wine', value: wineCount, inline: true },
+                        { name: '🥃 Liqour', value: liquorCount, inline: true }
+                    )
+
+                message.channel.send(embed);
+            })             
+    }
+}
+
+module.exports = DrinkingManager;

--- a/modules/informationModule.js
+++ b/modules/informationModule.js
@@ -33,7 +33,9 @@ var InfoManager = function (bot){
     "**!gif *search-terms*** : Returns a gif matching your search terms \r" +
     "**!ffxiv-set [Name]|[Server]** : Searches for a character to associate to your DiscordID. Example \`!ffxiv-set Sephiroth|Cactuar\` \r" +
     "**!ffxiv-clear** : Clears the associated character from your DiscordID \r" +
-    "**!ffxiv-show** : Shows your associated FFXIV character's profile and class jobs");
+    "**!ffxiv-show** : Shows your associated FFXIV character's profile and class jobs \r" +
+    "**!cheers [:beer:, :wine_glass:, or :tumbler_glass:]** : When you have one, Shamebot will drink with you! \r" +
+    "**!drunk** : Checks Shamebot's BAC without pouring him another");
 
     message.reply(infoEmbedBuilder(title, details));
   }


### PR DESCRIPTION
**What's New**
- Adds Shamebot Drinking Buddy!
- Adds !cheers 🍺🍷🥃 command. Saves a record to the MongoDB.
- Adds !drunk to pull all records from the last 24 hours, and calculates the BAC of Shamebot using the Widmark formular, assuming that Shamebot is 240lbs (Homer Simpson & Macho Man Randy Savage) and Male

**Notes** Saving all records for now in case we want to play with that data further. Could show the server's preferred kind of drinks, show when drinking happens most often, etc. Does _not_ save any user ID to associate with the drinks consumed.

![image](https://user-images.githubusercontent.com/38289430/112101231-b394a180-8b7c-11eb-9d23-44a20aae2810.png)
